### PR TITLE
Pacobart/management custom hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ These variables have default values and don't have to be set to use this module.
 |------|-------------|------|---------|
 | f5\_username | The admin username of the F5   BIG-IP that will be deployed | `string` | bigipuser |
 | f5\_password | Password of the F5  BIG-IP that will be deployed | `string` | "" |
+| f5\_hostname | Custom management hostname. Defaults to managemet public dns | `string` | "" |
 | ec2_instance_type  | AWS EC2 instance type  | `string`  | m5.large  |
 | f5_ami_search_name  | BIG-IP AMI name to search for  | `string`  | F5 BIGIP-* PAYG-Best 200Mbps*  |
 | aws_secretmanager_auth  | Whether to use key vault to pass authentication  | `bool`  | FALSE  |

--- a/locals.tf
+++ b/locals.tf
@@ -135,15 +135,21 @@ locals {
     }
   )
 
+  f5_hostname = var.f5_hostname != "" ? var.f5_hostname : (
+    length(aws_eip.mgmt) > 0 ? aws_eip.mgmt[0].public_dns : ""
+  ) #need to solve for edge cases here...like if public_ip = false on mgmt
+
   clustermemberDO1 = local.total_nics == 1 ? templatefile("${path.module}/templates/onboard_do_1nic.tpl", {
-    hostname      = length(aws_eip.mgmt) > 0 ? aws_eip.mgmt[0].public_dns : ""
+    #hostname      = length(aws_eip.mgmt) > 0 ? aws_eip.mgmt[0].public_dns : ""
+    hostname      = local.f5_hostname
     name_servers  = join(",", formatlist("\"%s\"", ["169.254.169.253"]))
     search_domain = "f5.com"
     ntp_servers   = join(",", formatlist("\"%s\"", ["169.254.169.123"]))
   }) : ""
 
   clustermemberDO2 = local.total_nics == 2 ? templatefile("${path.module}/templates/onboard_do_2nic.tpl", {
-    hostname      = length(aws_eip.mgmt) > 0 ? aws_eip.mgmt[0].public_dns : ""
+    #hostname      = length(aws_eip.mgmt) > 0 ? aws_eip.mgmt[0].public_dns : ""
+    hostname      = local.f5_hostname
     name_servers  = join(",", formatlist("\"%s\"", ["169.254.169.253"]))
     search_domain = "f5.com"
     ntp_servers   = join(",", formatlist("\"%s\"", ["169.254.169.123"]))
@@ -151,10 +157,6 @@ locals {
     self-ip       = local.selfip_list[0]
     gateway       = cidrhost(format("%s/24", local.selfip_list[0]), 1)
   }) : ""
-
-  f5_hostname = var.f5_hostname != "" ? var.f5_hostname : (
-    length(aws_eip.mgmt) > 0 ? aws_eip.mgmt[0].public_dns : ""
-  ) #need to solve for edge cases here...like if public_ip = false on mgmt...or length of mgmt ip
 
   clustermemberDO3 = local.total_nics >= 3 ? templatefile("${path.module}/templates/onboard_do_3nic.tpl", {
     #hostname      = length(aws_eip.mgmt) > 0 ? aws_eip.mgmt[0].public_dns : ""

--- a/locals.tf
+++ b/locals.tf
@@ -137,10 +137,9 @@ locals {
 
   f5_hostname = var.f5_hostname != "" ? var.f5_hostname : (
     length(aws_eip.mgmt) > 0 ? aws_eip.mgmt[0].public_dns : ""
-  ) #need to solve for edge cases here...like if public_ip = false on mgmt
+  )
 
   clustermemberDO1 = local.total_nics == 1 ? templatefile("${path.module}/templates/onboard_do_1nic.tpl", {
-    #hostname      = length(aws_eip.mgmt) > 0 ? aws_eip.mgmt[0].public_dns : ""
     hostname      = local.f5_hostname
     name_servers  = join(",", formatlist("\"%s\"", ["169.254.169.253"]))
     search_domain = "f5.com"
@@ -148,7 +147,6 @@ locals {
   }) : ""
 
   clustermemberDO2 = local.total_nics == 2 ? templatefile("${path.module}/templates/onboard_do_2nic.tpl", {
-    #hostname      = length(aws_eip.mgmt) > 0 ? aws_eip.mgmt[0].public_dns : ""
     hostname      = local.f5_hostname
     name_servers  = join(",", formatlist("\"%s\"", ["169.254.169.253"]))
     search_domain = "f5.com"
@@ -159,7 +157,6 @@ locals {
   }) : ""
 
   clustermemberDO3 = local.total_nics >= 3 ? templatefile("${path.module}/templates/onboard_do_3nic.tpl", {
-    #hostname      = length(aws_eip.mgmt) > 0 ? aws_eip.mgmt[0].public_dns : ""
     hostname      = local.f5_hostname
     name_servers  = join(",", formatlist("\"%s\"", ["169.254.169.253"]))
     search_domain = "f5.com"

--- a/locals.tf
+++ b/locals.tf
@@ -152,8 +152,13 @@ locals {
     gateway       = cidrhost(format("%s/24", local.selfip_list[0]), 1)
   }) : ""
 
+  f5_hostname = var.f5_hostname != "" ? var.f5_hostname : (
+    length(aws_eip.mgmt) > 0 ? aws_eip.mgmt[0].public_dns : ""
+  ) #need to solve for edge cases here...like if public_ip = false on mgmt...or length of mgmt ip
+
   clustermemberDO3 = local.total_nics >= 3 ? templatefile("${path.module}/templates/onboard_do_3nic.tpl", {
-    hostname      = length(aws_eip.mgmt) > 0 ? aws_eip.mgmt[0].public_dns : ""
+    #hostname      = length(aws_eip.mgmt) > 0 ? aws_eip.mgmt[0].public_dns : ""
+    hostname      = local.f5_hostname
     name_servers  = join(",", formatlist("\"%s\"", ["169.254.169.253"]))
     search_domain = "f5.com"
     ntp_servers   = join(",", formatlist("\"%s\"", ["169.254.169.123"]))

--- a/variables.tf
+++ b/variables.tf
@@ -15,7 +15,8 @@ variable "f5_password" {
 }
 
 variable "f5_hostname" {
-  description = "custom f5_hostname. defaults to mgmt public dns"
+  description = "Custom management hostname. Defaults to managemet public dns."
+  type        = string
   default     = ""
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -14,6 +14,11 @@ variable "f5_password" {
   default     = ""
 }
 
+variable "f5_hostname" {
+  description = "custom f5_hostname. defaults to mgmt public dns"
+  default     = ""
+}
+
 variable "f5_ami_search_name" {
   description = "BIG-IP AMI name to search for"
   type        = string


### PR DESCRIPTION
Adding support for custom management hostname. This is needed as the default is to use the Elastic IP public dns. We don't use public IP's for our management interfaces and would like a custom hostname.